### PR TITLE
Use safe initialization in fn hex_result()

### DIFF
--- a/src/digest/mod.rs
+++ b/src/digest/mod.rs
@@ -54,12 +54,12 @@ pub trait Digest: Sized {
     ///
     /// If output length is less than `Digest::output_bytes`.
     fn result<T>(self, output: T) where T: AsMut<[u8]>;
+
     /// Returns hash as lowercase hexadecimal string
     fn hex_result(self) -> String {
         let size = Self::output_bytes();
         let mut hex = Vec::with_capacity(size * 2);
-        let mut buf = Vec::with_capacity(size);
-        unsafe { buf.set_len(size); }
+        let mut buf = vec![0u8; size];
         self.result(&mut buf[..]);
 
         for b in buf {

--- a/src/mac/mod.rs
+++ b/src/mac/mod.rs
@@ -21,12 +21,12 @@ pub trait MAC: Sized {
     ///
     /// If output length is less than `Digest::output_bytes`.
     fn result<T>(self, output: T) where T: AsMut<[u8]>;
+
     /// Returns hash as lowercase hexadecimal string
     fn hex_result(self) -> String {
         let size = Self::output_bytes();
         let mut hex = Vec::with_capacity(size * 2);
-        let mut buf = Vec::with_capacity(size);
-        unsafe { buf.set_len(size); }
+        let mut buf = vec![0u8; size];
         self.result(&mut buf[..]);
 
         for b in buf {


### PR DESCRIPTION
Use safe initialization in fn hex_result()

fn hex_result would pass a slice of uninitialized data to Digest::result
and MAC::result respectively.

Instead use `vec![0; size]` to produce a properly zero-initialized
vector instead.

Motivation:
- Properly initializing buffers is good practice for crypto libraries
- Using unintialized buffers mean you have to audit all users (all fn
  result implementors).
- Using uninitialized buffers make the traits unsafe! Safe code gets
  acess to uninit data, which produces UB in safe rust.
- `vec![0; size]` compiles to good code (it will use memset).
