### PR TITLE
Cleanup benches

### DIFF
--- a/benches/digest/md4.rs
+++ b/benches/digest/md4.rs
@@ -2,9 +2,4 @@ use test::Bencher;
 
 use octavo::digest::md4::Md4;
 
-bench_digest!(bench_16, Md4, 16);
-bench_digest!(bench_128, Md4, 128);
-bench_digest!(bench_256, Md4, 256);
-bench_digest!(bench_512, Md4, 512);
-bench_digest!(bench_1k, Md4, 1024);
-bench_digest!(bench_10k, Md4, 10240);
+bench_digest!(Md4);

--- a/benches/digest/md5.rs
+++ b/benches/digest/md5.rs
@@ -2,9 +2,4 @@ use test::Bencher;
 
 use octavo::digest::md5::Md5;
 
-bench_digest!(bench_16, Md5, 16);
-bench_digest!(bench_128, Md5, 128);
-bench_digest!(bench_256, Md5, 256);
-bench_digest!(bench_512, Md5, 512);
-bench_digest!(bench_1k, Md5, 1024);
-bench_digest!(bench_10k, Md5, 10240);
+bench_digest!(Md5);

--- a/benches/digest/mod.rs
+++ b/benches/digest/mod.rs
@@ -1,22 +1,28 @@
 macro_rules! bench_digest {
-    ($name:ident, $engine:path, $bytes:expr) => {
+    ($name:ident, $engine:path, $blocks:expr) => {
         #[bench]
         fn $name(b: &mut Bencher) {
             use octavo::digest::Digest;
 
+            let bs = <$engine>::block_size();
+
             let mut d = <$engine>::default();
-            let data = vec![0; $bytes];
+            let data = vec![0; bs];
 
             b.iter(|| {
-                d.update(&data[..]);
+                for _ in 0..$blocks {
+                    d.update(&data[..]);
+                }
             });
 
-            b.bytes = $bytes as u64;
+            b.bytes = bs as u64 * $blocks;
         }
     };
 
     ($engine:path) => {
-        bench_digest!(bench_block_size, $engine, <$engine>::block_size());
+        bench_digest!(bench_1x_lock_size,    $engine,   1);
+        bench_digest!(bench_10x_block_size,  $engine,  10);
+        bench_digest!(bench_100x_block_size, $engine, 100);
     }
 }
 

--- a/benches/digest/mod.rs
+++ b/benches/digest/mod.rs
@@ -5,14 +5,18 @@ macro_rules! bench_digest {
             use octavo::digest::Digest;
 
             let mut d = <$engine>::default();
-            let data = [0; $bytes];
+            let data = vec![0; $bytes];
 
             b.iter(|| {
                 d.update(&data[..]);
             });
 
-            b.bytes = $bytes;
+            b.bytes = $bytes as u64;
         }
+    };
+
+    ($engine:path) => {
+        bench_digest!(bench_block_size, $engine, <$engine>::block_size());
     }
 }
 
@@ -21,3 +25,4 @@ macro_rules! bench_digest {
 #[cfg(feature = "sha1")] #[macro_use] mod sha1;
 #[cfg(feature = "sha2")] #[macro_use] mod sha2;
 #[cfg(feature = "sha3")] #[macro_use] mod sha3;
+#[cfg(feature = "tiger")] #[macro_use] mod tiger;

--- a/benches/digest/sha1.rs
+++ b/benches/digest/sha1.rs
@@ -2,9 +2,4 @@ use test::Bencher;
 
 use octavo::digest::sha1::Sha1;
 
-bench_digest!(bench_16, Sha1, 16);
-bench_digest!(bench_128, Sha1, 128);
-bench_digest!(bench_256, Sha1, 256);
-bench_digest!(bench_512, Sha1, 512);
-bench_digest!(bench_1k, Sha1, 1024);
-bench_digest!(bench_10k, Sha1, 10240);
+bench_digest!(Sha1);

--- a/benches/digest/sha2.rs
+++ b/benches/digest/sha2.rs
@@ -3,12 +3,7 @@ mod sha224 {
 
     use octavo::digest::sha2;
 
-    bench_digest!(bench_16, sha2::Sha224, 16);
-    bench_digest!(bench_128, sha2::Sha224, 128);
-    bench_digest!(bench_256, sha2::Sha224, 256);
-    bench_digest!(bench_512, sha2::Sha224, 512);
-    bench_digest!(bench_1k, sha2::Sha224, 1024);
-    bench_digest!(bench_10k, sha2::Sha224, 10240);
+    bench_digest!(sha2::Sha224);
 }
 
 mod sha256 {
@@ -16,12 +11,7 @@ mod sha256 {
 
     use octavo::digest::sha2;
 
-    bench_digest!(bench_16, sha2::Sha256, 16);
-    bench_digest!(bench_128, sha2::Sha256, 128);
-    bench_digest!(bench_256, sha2::Sha256, 256);
-    bench_digest!(bench_512, sha2::Sha256, 512);
-    bench_digest!(bench_1k, sha2::Sha256, 1024);
-    bench_digest!(bench_10k, sha2::Sha256, 10240);
+    bench_digest!(sha2::Sha256);
 }
 
 mod sha384 {
@@ -29,12 +19,7 @@ mod sha384 {
 
     use octavo::digest::sha2;
 
-    bench_digest!(bench_16, sha2::Sha384, 16);
-    bench_digest!(bench_128, sha2::Sha384, 128);
-    bench_digest!(bench_256, sha2::Sha384, 256);
-    bench_digest!(bench_512, sha2::Sha384, 512);
-    bench_digest!(bench_1k, sha2::Sha384, 1024);
-    bench_digest!(bench_10k, sha2::Sha384, 10240);
+    bench_digest!(sha2::Sha384);
 }
 
 mod sha512 {
@@ -42,10 +27,5 @@ mod sha512 {
 
     use octavo::digest::sha2;
 
-    bench_digest!(bench_16, sha2::Sha512, 16);
-    bench_digest!(bench_128, sha2::Sha512, 128);
-    bench_digest!(bench_256, sha2::Sha512, 256);
-    bench_digest!(bench_512, sha2::Sha512, 512);
-    bench_digest!(bench_1k, sha2::Sha512, 1024);
-    bench_digest!(bench_10k, sha2::Sha512, 10240);
+    bench_digest!(sha2::Sha512);
 }

--- a/benches/digest/sha3.rs
+++ b/benches/digest/sha3.rs
@@ -3,12 +3,7 @@ mod sha224 {
 
     use octavo::digest::sha3;
 
-    bench_digest!(bench_16, sha3::Sha3224, 16);
-    bench_digest!(bench_128, sha3::Sha3224, 128);
-    bench_digest!(bench_256, sha3::Sha3224, 256);
-    bench_digest!(bench_512, sha3::Sha3224, 512);
-    bench_digest!(bench_1k, sha3::Sha3224, 1024);
-    bench_digest!(bench_10k, sha3::Sha3224, 10240);
+    bench_digest!(sha3::Sha3224);
 }
 
 mod sha256 {
@@ -16,12 +11,7 @@ mod sha256 {
 
     use octavo::digest::sha3;
 
-    bench_digest!(bench_16, sha3::Sha3256, 16);
-    bench_digest!(bench_128, sha3::Sha3256, 128);
-    bench_digest!(bench_256, sha3::Sha3256, 256);
-    bench_digest!(bench_512, sha3::Sha3256, 512);
-    bench_digest!(bench_1k, sha3::Sha3256, 1024);
-    bench_digest!(bench_10k, sha3::Sha3256, 10240);
+    bench_digest!(sha3::Sha3256);
 }
 
 mod sha384 {
@@ -29,12 +19,7 @@ mod sha384 {
 
     use octavo::digest::sha3;
 
-    bench_digest!(bench_16, sha3::Sha3384, 16);
-    bench_digest!(bench_128, sha3::Sha3384, 128);
-    bench_digest!(bench_256, sha3::Sha3384, 256);
-    bench_digest!(bench_512, sha3::Sha3384, 512);
-    bench_digest!(bench_1k, sha3::Sha3384, 1024);
-    bench_digest!(bench_10k, sha3::Sha3384, 10240);
+    bench_digest!(sha3::Sha3384);
 }
 
 mod sha512 {
@@ -42,10 +27,5 @@ mod sha512 {
 
     use octavo::digest::sha3;
 
-    bench_digest!(bench_16, sha3::Sha3512, 16);
-    bench_digest!(bench_128, sha3::Sha3512, 128);
-    bench_digest!(bench_256, sha3::Sha3512, 256);
-    bench_digest!(bench_512, sha3::Sha3512, 512);
-    bench_digest!(bench_1k, sha3::Sha3512, 1024);
-    bench_digest!(bench_10k, sha3::Sha3512, 10240);
+    bench_digest!(sha3::Sha3512);
 }

--- a/benches/digest/tiger.rs
+++ b/benches/digest/tiger.rs
@@ -2,9 +2,4 @@ use test::Bencher;
 
 use octavo::digest::tiger::Tiger;
 
-bench_digest!(bench_16, Tiger, 16);
-bench_digest!(bench_128, Tiger, 128);
-bench_digest!(bench_256, Tiger, 256);
-bench_digest!(bench_512, Tiger, 512);
-bench_digest!(bench_1k, Tiger, 1024);
-bench_digest!(bench_10k, Tiger, 10240);
+bench_digest!(Tiger);

--- a/src/digest/sha3.rs
+++ b/src/digest/sha3.rs
@@ -198,7 +198,7 @@ macro_rules! sha3_impl {
             }
 
             fn output_bits() -> usize { $size }
-            fn block_size() -> usize { 1600 - (2 * $size) }
+            fn block_size() -> usize { (1600 - (2 * $size)) / 8 }
 
             fn result<T>(mut self, mut out: T) where T: AsMut<[u8]> {
                 let mut ret = out.as_mut();


### PR DESCRIPTION
- use block size as base for benchmarks (that will always fire update on state)
- use macro to build all benchmarks instead of repeating code

Ref #39
