### PR TITLE
Do not use slices if not needed

### DIFF
--- a/benches/digest/mod.rs
+++ b/benches/digest/mod.rs
@@ -11,7 +11,7 @@ macro_rules! bench_digest {
 
             b.iter(|| {
                 for _ in 0..$blocks {
-                    d.update(&data[..]);
+                    d.update(&data);
                 }
             });
 


### PR DESCRIPTION
Slices syntax introduce big performance loss (in order of magnitude or greater). Avoid it to provide better performance in benches.
