### PR TITLE
refactor(digest::ripemd): Unwrap loop

### DIFF
--- a/src/digest/ripemd.rs
+++ b/src/digest/ripemd.rs
@@ -4,34 +4,52 @@ use typenum::consts::{U20, U64, U160};
 use digest::Digest;
 use utils::buffer::{FixedBuf, FixedBuffer64, StandardPadding};
 
-const LEFT_PICK: [usize; 80] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 7, 4, 13, 1,
-                                10, 6, 15, 3, 12, 0, 9, 5, 2, 14, 11, 8, 3, 10, 14, 4, 9, 15, 8,
-                                1, 2, 7, 0, 6, 13, 11, 5, 12, 1, 9, 11, 10, 0, 8, 12, 4, 13, 3, 7,
-                                15, 14, 5, 6, 2, 4, 0, 5, 9, 7, 12, 2, 10, 14, 1, 3, 8, 11, 6, 15,
-                                13];
-const RIGHT_PICK: [usize; 80] = [5, 14, 7, 0, 9, 2, 11, 4, 13, 6, 15, 8, 1, 10, 3, 12, 6, 11, 3,
-                                 7, 0, 13, 5, 10, 14, 15, 8, 12, 4, 9, 1, 2, 15, 5, 1, 3, 7, 14,
-                                 6, 9, 11, 8, 12, 2, 10, 0, 4, 13, 8, 6, 4, 1, 3, 11, 15, 0, 5,
-                                 12, 2, 13, 9, 7, 10, 14, 12, 15, 10, 4, 1, 5, 8, 7, 6, 2, 13, 14,
-                                 0, 3, 9, 11];
-
-const LEFT_ROTATE: [u32; 80] = [11, 14, 15, 12, 5, 8, 7, 9, 11, 13, 14, 15, 6, 7, 9, 8, 7, 6, 8,
-                                13, 11, 9, 7, 15, 7, 12, 15, 9, 11, 7, 13, 12, 11, 13, 6, 7, 14,
-                                9, 13, 15, 14, 8, 13, 6, 5, 12, 7, 5, 11, 12, 14, 15, 14, 15, 9,
-                                8, 9, 14, 5, 6, 8, 6, 5, 12, 9, 15, 5, 11, 6, 8, 13, 12, 5, 12,
-                                13, 14, 11, 8, 5, 6];
-const RIGHT_ROTATE: [u32; 80] = [8, 9, 9, 11, 13, 15, 15, 5, 7, 7, 8, 11, 14, 14, 12, 6, 9, 13,
-                                 15, 7, 12, 8, 9, 11, 7, 7, 12, 7, 6, 15, 13, 11, 9, 7, 15, 11, 8,
-                                 6, 6, 14, 12, 13, 5, 14, 13, 13, 7, 5, 15, 5, 8, 11, 14, 14, 6,
-                                 14, 6, 9, 12, 9, 12, 5, 15, 8, 8, 5, 12, 9, 12, 5, 14, 6, 8, 13,
-                                 6, 5, 15, 13, 11, 11];
-
-const LEFT_CONST: [u32; 5] = [0x00000000, 0x5A827999, 0x6ED9EBA1, 0x8F1BBCDC, 0xA953FD4E];
-const RIGHT_CONST: [u32; 5] = [0x50A28BE6, 0x5C4DD124, 0x6D703EF3, 0x7A6D76E9, 0x00000000];
-
 #[derive(Copy, Clone, Debug)]
 struct State {
     state: [u32; 5],
+}
+
+macro_rules! process {
+    () => {};
+    (proc $block:ident, $value:expr, $rot:expr, $c:expr, $func:block) => {{
+        let tmp = $block[0]
+            .wrapping_add($func)
+            .wrapping_add($value)
+            .wrapping_add($c)
+            .rotate_left($rot)
+            .wrapping_add($block[4]);
+        $block[0] = $block[4];
+        $block[4] = $block[3];
+        $block[3] = $block[2].rotate_left(10);
+        $block[2] = $block[1];
+        $block[1] = tmp;
+    }};
+    (ff $block:ident, $value:expr, $rot:expr, $c:expr; $($rest:tt)*) => {
+        process!(proc $block, $value, $rot, $c, { $block[1] ^ $block[2] ^ $block[3] });
+        process!($($rest)*);
+    };
+    (gg $block:ident, $value:expr, $rot:expr, $c:expr; $($rest:tt)*) => {
+        process!(proc $block, $value, $rot, $c, { ($block[1] & $block[2]) | (!$block[1] & $block[3]) });
+        process!($($rest)*);
+    };
+    (hh $block:ident, $value:expr, $rot:expr, $c:expr; $($rest:tt)*) => {
+        process!(proc $block, $value, $rot, $c, { ($block[1] | !$block[2]) ^ $block[3] });
+        process!($($rest)*);
+    };
+    (ii $block:ident, $value:expr, $rot:expr, $c:expr; $($rest:tt)*) => {
+        process!(proc $block, $value, $rot, $c, { ($block[1] & $block[3]) | ($block[2] & !$block[3]) });
+        process!($($rest)*);
+    };
+    (jj $block:ident, $value:expr, $rot:expr, $c:expr; $($rest:tt)*) => {
+        process!(proc $block, $value, $rot, $c, { $block[1] ^ ($block[2] | !$block[3]) });
+        process!($($rest)*);
+    };
+    ($block:ident;
+     $round:ident($c:expr, $($v:expr => $r:expr),*)) => {
+        process! {
+            $($round $block, $v, $r, $c;)*
+        }
+    };
 }
 
 impl State {
@@ -42,40 +60,6 @@ impl State {
     fn process_block(&mut self, block: &[u8]) {
         debug_assert!(block.len() == 64);
 
-        fn ff(x: u32, y: u32, z: u32) -> u32 {
-            x ^ y ^ z
-        }
-        fn gg(x: u32, y: u32, z: u32) -> u32 {
-            (x & y) | (!x & z)
-        }
-        fn hh(x: u32, y: u32, z: u32) -> u32 {
-            (x | !y) ^ z
-        }
-        fn ii(x: u32, y: u32, z: u32) -> u32 {
-            (x & z) | (y & !z)
-        }
-        fn jj(x: u32, y: u32, z: u32) -> u32 {
-            x ^ (y | !z)
-        }
-
-        let funcs: [fn(u32, u32, u32) -> u32; 5] = [ff, gg, hh, ii, jj];
-
-        fn process<F>(block: &mut [u32], value: u32, rot: u32, c: u32, func: F)
-            where F: Fn(u32, u32, u32) -> u32
-        {
-            let tmp = block[0]
-                          .wrapping_add(func(block[1], block[2], block[3]))
-                          .wrapping_add(value)
-                          .wrapping_add(c)
-                          .rotate_left(rot)
-                          .wrapping_add(block[4]);
-            block[0] = block[4];
-            block[4] = block[3];
-            block[3] = block[2].rotate_left(10);
-            block[2] = block[1];
-            block[1] = tmp;
-        }
-
         let mut data = [0u32; 16];
 
         for (c, v) in block.chunks(4).zip(data.iter_mut()) {
@@ -85,18 +69,57 @@ impl State {
         let mut left = self.state.clone();
         let mut right = self.state.clone();
 
-        for i in 0..80 {
-            process(&mut left,
-                    data[LEFT_PICK[i]],
-                    LEFT_ROTATE[i],
-                    LEFT_CONST[i / 16],
-                    funcs[i / 16]);
-            process(&mut right,
-                    data[RIGHT_PICK[i]],
-                    RIGHT_ROTATE[i],
-                    RIGHT_CONST[i / 16],
-                    funcs[4 - (i / 16)]);
-        }
+        process!(left; ff(0x00000000,
+                          data[0 ] => 11, data[1 ] => 14, data[2 ] => 15, data[3 ] => 12,
+                          data[4 ] => 5 , data[5 ] => 8 , data[6 ] => 7 , data[7 ] => 9 ,
+                          data[8 ] => 11, data[9 ] => 13, data[10] => 14, data[11] => 15,
+                          data[12] => 6 , data[13] => 7 , data[14] => 9 , data[15] => 8));
+        process!(left; gg(0x5a827999,
+                          data[7 ] => 7 , data[4 ] => 6 , data[13] => 8 , data[1 ] => 13,
+                          data[10] => 11, data[6 ] => 9 , data[15] => 7 , data[3 ] => 15,
+                          data[12] => 7 , data[0 ] => 12, data[9 ] => 15, data[5 ] => 9 ,
+                          data[2 ] => 11, data[14] => 7 , data[11] => 13, data[8 ] => 12));
+        process!(left; hh(0x6ed9eba1,
+                          data[3 ] => 11, data[10] => 13, data[14] => 6 , data[4 ] => 7 ,
+                          data[9 ] => 14, data[15] => 9 , data[8 ] => 13, data[1 ] => 15,
+                          data[2 ] => 14, data[7 ] => 8 , data[0 ] => 13, data[6 ] => 6 ,
+                          data[13] => 5 , data[11] => 12, data[5 ] => 7 , data[12] => 5));
+        process!(left; ii(0x8f1bbcdc,
+                          data[1 ] => 11, data[9 ] => 12, data[11] => 14, data[10] => 15,
+                          data[0 ] => 14, data[8 ] => 15, data[12] => 9 , data[4 ] => 8,
+                          data[13] => 9 , data[3 ] => 14, data[7 ] => 5 , data[15] => 6,
+                          data[14] => 8 , data[5 ] => 6 , data[6 ] => 5 , data[2 ] => 12));
+        process!(left; jj(0xa953fd4e,
+                          data[4 ] => 9 , data[0 ] => 15, data[5 ] => 5 , data[9 ] => 11,
+                          data[7 ] => 6 , data[12] => 8 , data[2 ] => 13, data[10] => 12,
+                          data[14] => 5 , data[1 ] => 12, data[3 ] => 13, data[8 ] => 14,
+                          data[11] => 11, data[6 ] => 8 , data[15] => 5 , data[13] => 6));
+
+        process!(right; jj(0x50a28be6,
+                           data[5 ] => 8,  data[14] => 9 , data[7 ] => 9 , data[0 ] => 11,
+                           data[9 ] => 13, data[2 ] => 15, data[11] => 15, data[4 ] => 5 ,
+                           data[13] => 7 , data[6 ] => 7 , data[15] => 8,  data[8 ] => 11,
+                           data[1 ] => 14, data[10] => 14, data[3 ] => 12, data[12] => 6));
+        process!(right; ii(0x5c4dd124,
+                           data[6 ] => 9 , data[11] => 13, data[3 ] => 15, data[7 ] => 7,
+                           data[0 ] => 12, data[13] => 8 , data[5 ] => 9 , data[10] => 11,
+                           data[14] => 7 , data[15] => 7 , data[8 ] => 12, data[12] => 7 ,
+                           data[4 ] => 6 , data[9 ] => 15, data[1 ] => 13, data[2 ] => 11));
+        process!(right; hh(0x6d703ef3,
+                           data[15] => 9 , data[5 ] => 7 , data[1 ] => 15, data[3 ] => 11,
+                           data[7 ] => 8 , data[14] => 6 , data[6 ] => 6 , data[9 ] => 14,
+                           data[11] => 12, data[8 ] => 13, data[12] => 5 , data[2 ] => 14,
+                           data[10] => 13, data[0 ] => 13, data[4 ] => 7 , data[13] => 5));
+        process!(right; gg(0x7a6d76e9,
+                           data[8 ] => 15, data[6 ] => 5 , data[4 ] => 8 , data[1 ] => 11,
+                           data[3 ] => 14, data[11] => 14, data[15] => 6 , data[0 ] => 14,
+                           data[5 ] => 6 , data[12] => 9 , data[2 ] => 12, data[13] => 9 ,
+                           data[9 ] => 12, data[7 ] => 5 , data[10] => 15, data[14] => 8));
+        process!(right; ff(0x00000000,
+                           data[12] => 8 , data[15] => 5 , data[10] => 12, data[4 ] => 9 ,
+                           data[1 ] => 12, data[5 ] => 5 , data[8 ] => 14, data[7 ] => 6 ,
+                           data[6 ] => 8 , data[2 ] => 13, data[13] => 6 , data[14] => 5 ,
+                           data[0 ] => 15, data[3 ] => 13, data[9 ] => 11, data[11] => 11));
 
         let tmp = self.state[1].wrapping_add(left[2]).wrapping_add(right[3]);
         self.state[1] = self.state[2].wrapping_add(left[3]).wrapping_add(right[4]);
@@ -132,13 +155,13 @@ impl Digest for Ripemd160 {
 
     fn update<T>(&mut self, update: T)
         where T: AsRef<[u8]>
-    {
-        let update = update.as_ref();
-        self.length += update.len() as u64;
+        {
+            let update = update.as_ref();
+            self.length += update.len() as u64;
 
-        let state = &mut self.state;
-        self.buffer.input(update, |d| state.process_block(d));
-    }
+            let state = &mut self.state;
+            self.buffer.input(update, |d| state.process_block(d));
+        }
 
     fn result<T: AsMut<[u8]>>(mut self, mut out: T) {
         let state = &mut self.state;

--- a/tests/digest/mod.rs
+++ b/tests/digest/mod.rs
@@ -36,7 +36,7 @@ impl<T> Testable for T where T: Digest + Sized
 
         self.result(&mut output[..]);
         assert!(test.output == &output[..],
-                "Input: {:?} (str: {})\nExpected: {:?}\nGot: {:?}",
+                "Input: {:?} (str: \"{}\")\nExpected: {:?}\nGot: {:?}",
                 test.input,
                 str::from_utf8(test.input).unwrap_or("<non-UTF8>"),
                 test.output,


### PR DESCRIPTION
Old:

```
digest::ripemd::_100x_block_size  102,215 ns/iter (+/- 268,471) =  62 MB/s
digest::ripemd::_10x_block_size    10,199 ns/iter (+/- 34,334)  =  62 MB/s
digest::ripemd::_1x_block_size      1,024 ns/iter (+/- 1,477)   =  62 MB/s
```

New:

```
digest::ripemd::_100x_block_size   34,825 ns/iter (+/- 162)     = 183 MB/s
digest::ripemd::_10x_block_size     3,485 ns/iter (+/- 50)      = 183 MB/s
digest::ripemd::_1x_block_size        351 ns/iter (+/- 7)       = 182 MB/s
```
