### PR TITLE
fixed: error[E0658]: use of unstable library feature 'wrapping_int_im…

### DIFF
--- a/digest/src/lib.rs
+++ b/digest/src/lib.rs
@@ -39,6 +39,7 @@
 
 #![allow(inline_always, unknown_lints)]
 #![forbid(overflowing_literals, missing_docs)]
+#![feature(wrapping_int_impl)]
 
 extern crate generic_array;
 extern crate static_buffer;


### PR DESCRIPTION
error[E0658]: use of unstable library feature 'wrapping_int_impl' (see issue #32463)
added #![feature(wrapping_int_impl)] to digest/src/lib.rs